### PR TITLE
upgrade pip and setuptools in the virtualenv

### DIFF
--- a/virtualenv-bootstrap.sh
+++ b/virtualenv-bootstrap.sh
@@ -340,7 +340,7 @@ echo "Detected distribution release: $DISTRIB_RELEASE"
 
 
 #################################################################
-#           Global package installation (distribition-specific)
+#           Global package installation (distribution-specific)
 #################################################################
 NONINTERACTIVEFLAG=""
 if [ "$NOADMIN" == "0" ]; then
@@ -882,10 +882,14 @@ for project in $PROJECTS; do
 done
 
 
-echo 
+echo
 echo "--------------------------------------------------------------"
 echo "Installing Python dependencies from the Python Package Index"
 echo "--------------------------------------------------------------"
+# upgrade pip itself and setuptools in the virtualenv
+python -m pip install --upgrade pip
+pip install --upgrade setuptools
+
 if [ $NOPYTHONDEPS -eq 0 ]; then
     PYTHONDEPS="cython numpy ipython scipy matplotlib lxml scikit-learn django pycrypto pandas textblob nltk psutil flask requests requests_toolbelt requests_oauthlib"
     if [ -z "$VERSIONFILE" ]; then


### PR DESCRIPTION
When installing LaMachine on Debian 8 I got the error `ImportError: No module named packaging.version`. The fix is explained here: https://gist.github.com/hangtwenty/b9820fe204eebb0cc5b9aba49f3c8b22.

This may also help in issue #20.